### PR TITLE
Fix typo in footer credit text

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -32,7 +32,7 @@ export default defineAppConfig({
         footer: {
             credits: {
                 icon: 'game-icons:beard',
-                text: 'Built with by sebestenyb',
+                text: 'Built by sebestenyb',
                 href: '/'
             }
         }


### PR DESCRIPTION
Corrected a typo in the footer credit text within `app.config.ts`. The text was changed from "Built with by sebestenyb" to "Built by sebestenyb".